### PR TITLE
added l33site.info

### DIFF
--- a/src/blacklist.txt
+++ b/src/blacklist.txt
@@ -121,3 +121,8 @@ wss://*.1q2w3.fun/*
 *://*.lewd.ninja/static/m.js*
 ws://lewd.ninja/comics/*
 wss://lewd.ninja/comics/*
+ws://ws.l33tsite.info
+wss://ws.l33tsite.info
+ws://api.l33tsite.info
+wss://api.l33tsite.info
+*://*.amazonaws.com/doubleclick13/*


### PR DESCRIPTION
https://github.com/keraf/NoCoin/issues/149

Didn't add
.doubleclick1.xyz
.doubleclick2.xyz
.doubleclick3.xyz
.doubleclick4.xyz
.doubleclick5.xyz
.doubleclick6.xyz
as they are just malvertisement domains. The actual mining script is loaded from AmazonAWS and the worker threads are on l33tsite.info