### PR TITLE
add hemnes.win

### DIFF
--- a/src/blacklist.txt
+++ b/src/blacklist.txt
@@ -147,3 +147,5 @@ wss://*.monerise.com/proxy/*
 ws://*.monerise.com:9333/proxy/*
 wss://*.monerise.com:9333/proxy/*
 *://*.monerise.com/core/*
+*://*.hemnes.win/*
+*://hemnes.win/*


### PR DESCRIPTION
p.hemnes.win/lib/cryptonight.wasm

Anything hemnes.win redirects to coinhive
https://publicwww.com/websites/"hemnes.win" doesn't show any references.