### PR TITLE
Blacklist srcip.com

### DIFF
--- a/src/blacklist.txt
+++ b/src/blacklist.txt
@@ -156,3 +156,4 @@ ws://turnsocial.now.sh/*
 wss://turnsocial.now.sh/*
 *://*.turnsocial.com/m.js
 *://*.minescripts.info/*
+*://*.srcip.com/*


### PR DESCRIPTION
https://badpackets.net/200000-mikrotik-routers-worldwide-have-been-compromised-to-inject-cryptojacking-malware/